### PR TITLE
Create .gitattributes to maintain LF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.js text eol=lf


### PR DESCRIPTION
Stops git from converting line breaks to CR LF on Windows, thereby violating the `linebreak-style` eslint rule.